### PR TITLE
actions: automatically add all opened issues and PRs to project board

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,30 @@
+name: Add issues and PRs to project boards
+
+on:
+  workflow_call:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+permissions: read-all
+
+jobs:
+  add-to-project-boards:
+    name: Add issues and PRs to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # latest main
+        with:
+          project-url: https://github.com/orgs/osism/projects/20
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: renovate
+          label-operator: NOT
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # latest main
+        with:
+          project-url: https://github.com/orgs/osism/projects/21
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: renovate
+          label-operator: AND


### PR DESCRIPTION
* this action should run whenever issues or PRs are opened and should add them to either the "Bot Board" if they are created by bots (based on their label, e.g. renovate) or to the "Human Board"
* upstream action: https://github.com/actions/add-to-project
* the latest release of the action is currently v1.0.2 from mid 2024 so we can't really use this here to pin the version, but instead reference by commit (currently latest from main)
* make the workflow reusable, so we can call it from other PRs and Issues (to reduce code duplication)